### PR TITLE
Allow proxpass to be optional when backend is None

### DIFF
--- a/forevd/apache/httpd.conf
+++ b/forevd/apache/httpd.conf
@@ -134,8 +134,10 @@ LDAP{{ key }} {{ value }}
     {{ location["include"] }}
     {% endif -%}
 
+    {% if location["backend"] -%}
     ProxyPass {{ location["backend"] }}
     ProxyPassReverse {{ location["backend"] }}
+    {% endif -%}
 
     {% if authc["mtls"] and cert -%}
     SSLOptions +StdEnvVars


### PR DESCRIPTION
Allow proxpass to be optional when backend is None