### PR TITLE
fix build workflow, docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.venv
+__pycache__
+*.py[cod]
+.pytest_cache
+.mypy_cache
+.ruff_cache
+dist
+build
+*.egg-info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ jobs:
         python-version: ["3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-
 # GitHub recommends pinning actions to a commit SHA.
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
@@ -13,20 +12,24 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to GHCR
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +37,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,9 +23,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -41,3 +41,17 @@ jobs:
         run: |
           poetry run pylint forevd
           poetry run pycodestyle --config .pycodestyle forevd
+
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build Docker image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          push: false
+          tags: forevd:pr

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       run: poetry build
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,23 @@ FROM httpd:2.4
 RUN apt-get update
 
 RUN apt-get install --no-install-recommends -y \
-    ca-certificates libapache2-mod-auth-openidc libapache2-mod-proxy-wstunel \
-    python3 pip curl
+    ca-certificates libapache2-mod-auth-openidc \
+    python3 python-is-python3 pip curl
 
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
 RUN apt-get --yes remove curl
 
 RUN ln -sf /usr/lib/apache2/modules/mod_auth_openidc.so /usr/local/apache2/modules/mod_auth_openidc.so
-RUN ln -sf /usr/lib/apache2/modules/mod_proxy_wstunnel.so /usr/local/apache2/modules/mod_proxy_wstunnel.so
 
 COPY . /usr/local/forevd
 RUN rm -rf /usr/local/forevd/dist
 
 WORKDIR /usr/local/forevd
 
-ENV PATH="$PATH:/root/.local/bin"
+ENV PATH="/usr/local/apache2/bin:/root/.local/bin:${PATH}"
 RUN poetry install
 RUN poetry build
 
-ENV PIP_BREAK_SYSTEM_PACKAGES 1
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN pip install --verbose --upgrade dist/forevd-*.whl

--- a/forevd/apache/__init__.py
+++ b/forevd/apache/__init__.py
@@ -12,6 +12,29 @@ import jinja2
 
 _LOGGER = logging.getLogger(__name__)
 
+_HTTPD_CANDIDATES = (
+    "/usr/local/apache2/bin/httpd",
+    "/usr/sbin/httpd",
+    "/usr/sbin/apache2",
+)
+
+
+def _find_httpd() -> str:
+    """Find Apache in common package and container locations."""
+    httpd = shutil.which("httpd")
+    if httpd:
+        return httpd
+
+    for candidate in _HTTPD_CANDIDATES:
+        if os.path.exists(candidate):
+            return candidate
+
+    raise RuntimeError("Unable to find Apache httpd. Use --cmd to provide its path.")
+
+
+def _server_root(httpd: str) -> str:
+    return os.environ.get("FOREVD_HTTPD_ROOT", os.path.dirname(os.path.dirname(httpd)))
+
 
 def run(var_dir: str, config: dict, do_exec: bool, cmd: str = None):
     """Execute Apache given the config."""
@@ -39,7 +62,7 @@ def run(var_dir: str, config: dict, do_exec: bool, cmd: str = None):
 
     _LOGGER.debug(f"cmd: {cmd!r}")
     if not cmd:
-        httpd = shutil.which("httpd")
+        httpd = _find_httpd()
         _LOGGER.debug(f"httpd: {httpd}")
 
         cmd = [
@@ -49,7 +72,7 @@ def run(var_dir: str, config: dict, do_exec: bool, cmd: str = None):
             "-f",
             config_file,
             "-d",
-            "/opt/homebrew/Cellar/httpd/2.4.55/lib/httpd",
+            _server_root(httpd),
         ]
     else:
         cmd = shlex.split(cmd)


### PR DESCRIPTION
Signed-off-by: Daniel Guns <danbguns@gmail.com>

• ## Summary

  Fixed the Docker release build and added earlier CI coverage so the same issue is caught on PRs.

  ## Changes

  - Removed the invalid `libapache2-mod-proxy-wstunel` package from `Dockerfile`.
  - Added `python-is-python3` because Debian trixie provides `python3`, while Poetry expects `python`.
  - Added `/usr/local/apache2/bin` to the image `PATH` so `httpd` is discoverable at runtime.
  - Made Apache discovery portable in `forevd/apache/__init__.py` instead of hardcoding a Homebrew path.
  - Added `.dockerignore` to keep Docker build contexts small and clean.
  - Added a PR Docker build job using `docker/build-push-action@v7`.
  - Updated GitHub Actions to current major versions to avoid Node 20 deprecation failures on release.

  ## Verification

  - `poetry run pytest`
  - `poetry run black --check .`
  - `poetry run pylint forevd`
  - `poetry run pycodestyle --config .pycodestyle forevd`
  - `poetry build`
  - `docker build --no-cache -t forevd:local-test .`
  - Container smoke tests with `httpd -t`, including OIDC module loading
  
  
  closes #22